### PR TITLE
Fix picasso symbol error in apiClient

### DIFF
--- a/Movie/app/src/main/my/cinemax/app/free/api/apiClient.java
+++ b/Movie/app/src/main/my/cinemax/app/free/api/apiClient.java
@@ -279,8 +279,9 @@ public class apiClient {
 
     private static boolean isPicassoInitialized() {
         try {
-            // Attempt to get the singleton instance
-            Picasso.get();
+            // Attempt to get the singleton instance using the context
+            // In Picasso 2.5.2, we use Picasso.with() instead of Picasso.get()
+            Picasso.with(MyApplication.getInstance());
             return true;
         } catch (IllegalStateException e) {
             // If it throws IllegalStateException, it means it's not initialized yet


### PR DESCRIPTION
Fix `cannot find symbol` error by using `Picasso.with()` instead of `Picasso.get()` for Picasso 2.5.2 compatibility.

The project uses Picasso 2.5.2, which does not have the `Picasso.get()` method (introduced in later versions like 2.8+). This change updates the `isPicassoInitialized()` method to use `Picasso.with(MyApplication.getInstance())`, which is the correct API for the installed Picasso version, resolving the compilation error.

---

[Open in Web](https://cursor.com/agents?id=bc-73dc6eb5-c3fb-48a8-8ff9-ac7958d84699) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-73dc6eb5-c3fb-48a8-8ff9-ac7958d84699) • [Open Docs](https://docs.cursor.com/background-agent/web-and-mobile)