### PR TITLE
Investigate home screen content display issue

### DIFF
--- a/Movie/app/src/main/my/cinemax/app/free/api/PlaylistDataAdapter.java
+++ b/Movie/app/src/main/my/cinemax/app/free/api/PlaylistDataAdapter.java
@@ -57,9 +57,12 @@ public class PlaylistDataAdapter {
         data.setChannels(allChannels);
         data.setSlides(slides);
         
+        // Create genre sections from playlist categories
+        List<Genre> genres = createGenresFromCategories(playlistData);
+        data.setGenres(genres);
+        
         // Initialize other collections to empty lists to prevent null reference exceptions
         data.setActors(new ArrayList<>());
-        data.setGenres(new ArrayList<>());
         
         return data;
     }
@@ -226,5 +229,40 @@ public class PlaylistDataAdapter {
         }
         
         return seasons;
+    }
+    
+    private static List<Genre> createGenresFromCategories(PlaylistData playlistData) {
+        List<Genre> genres = new ArrayList<>();
+        
+        if (playlistData.getCategories() != null) {
+            for (PlaylistCategory category : playlistData.getCategories()) {
+                // Skip Live TV as it's handled as channels
+                if ("Live TV".equals(category.getMainCategory())) {
+                    continue;
+                }
+                
+                // Create a genre for each main category
+                Genre genre = new Genre();
+                genre.setId(category.getMainCategory().hashCode());
+                genre.setTitle(category.getMainCategory());
+                
+                // Get all posters for this category
+                List<Poster> categoryPosters = new ArrayList<>();
+                if (category.getEntries() != null) {
+                    for (PlaylistEntry entry : category.getEntries()) {
+                        Poster poster = convertToPoster(entry, category);
+                        categoryPosters.add(poster);
+                    }
+                }
+                genre.setPosters(categoryPosters);
+                
+                // Only add the genre if it has content
+                if (!categoryPosters.isEmpty()) {
+                    genres.add(genre);
+                }
+            }
+        }
+        
+        return genres;
     }
 }


### PR DESCRIPTION
<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
Populate movie and TV series genres in the home screen by correctly converting playlist categories.

<!-- OPTIONAL: If the WHY of the PR is not obvious, perhaps because it fixed a gnarly bug, explain it in a short paragraph here. E.g. "Commit a73bb98 introduced a bug where the class list was filtered to only work for MDC files, hence we partially revert it here." -->
Previously, the `genres` list was initialized as empty, preventing the display of movie and TV series sections on the home screen. This change ensures that `Genre` objects are properly created from playlist categories, allowing the home screen to display all content types (Movies, TV Series, and Live TV).

---

[Open in Web](https://cursor.com/agents?id=bc-2f168ef4-b8cf-4eb4-9afc-c047b3957359) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-2f168ef4-b8cf-4eb4-9afc-c047b3957359) • [Open Docs](https://docs.cursor.com/background-agent/web-and-mobile)