### PR TITLE
Diagnose app crash on play

### DIFF
--- a/Movie/app/src/main/my/cinemax/app/free/ui/activities/MovieActivity.java
+++ b/Movie/app/src/main/my/cinemax/app/free/ui/activities/MovieActivity.java
@@ -624,8 +624,11 @@ public class MovieActivity extends AppCompatActivity {
             loadRemoteMedia(0, true);
         } else {
             Intent intent = new Intent(MovieActivity.this,PlayerActivity.class);
+            intent.putExtra("id",poster.getId());
             intent.putExtra("url",poster.getTrailer().getUrl());
             intent.putExtra("type",poster.getTrailer().getType());
+            intent.putExtra("isLive",false); // Trailers are not live
+            intent.putExtra("kind","trailer");
             intent.putExtra("image",poster.getImage());
             intent.putExtra("title",poster.getTitle());
             intent.putExtra("subtitle",poster.getTitle() + " Trailer");

--- a/Movie/app/src/main/my/cinemax/app/free/ui/activities/PlayerActivity.java
+++ b/Movie/app/src/main/my/cinemax/app/free/ui/activities/PlayerActivity.java
@@ -145,15 +145,29 @@ public class PlayerActivity extends AppCompatActivity {
                 | View.SYSTEM_UI_FLAG_IMMERSIVE_STICKY);
         mScaleGestureDetector = new ScaleGestureDetector(this, new ScaleListener());
         mCastContext = CastContext.getSharedInstance(this);
-        Bundle bundle = getIntent().getExtras() ;
-        vodeoId = bundle.getInt("id");
-        videoUrl = bundle.getString("url");
-        videoKind = bundle.getString("kind");
-        isLive = bundle.getBoolean("isLive");
-        videoType = bundle.getString("type");
-        videoTitle = bundle.getString("title");
-        videoSubTile = bundle.getString("subtitle");
-        videoImage = bundle.getString("image");
+        Bundle bundle = getIntent().getExtras();
+        
+        // Add null check for bundle to prevent crash
+        if (bundle == null) {
+            finish(); // Close activity if no bundle is provided
+            return;
+        }
+        
+        vodeoId = bundle.getInt("id", 0);
+        videoUrl = bundle.getString("url", "");
+        videoKind = bundle.getString("kind", "");
+        isLive = bundle.getBoolean("isLive", false); // Default to false if not provided
+        videoType = bundle.getString("type", "");
+        videoTitle = bundle.getString("title", "");
+        videoSubTile = bundle.getString("subtitle", "");
+        videoImage = bundle.getString("image", "");
+        
+        // Validate essential parameters
+        if (videoUrl == null || videoUrl.trim().isEmpty()) {
+            Log.e("PlayerActivity", "Video URL is null or empty");
+            finish();
+            return;
+        }
         getWindow().addFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON);
 
         if (savedInstanceState == null) {

--- a/Movie/app/src/main/my/cinemax/app/free/ui/activities/SerieActivity.java
+++ b/Movie/app/src/main/my/cinemax/app/free/ui/activities/SerieActivity.java
@@ -726,8 +726,11 @@ public class SerieActivity extends AppCompatActivity implements PlaylistDownload
             loadRemoteMedia(0, true);
         } else {
             Intent intent = new Intent(SerieActivity.this,PlayerActivity.class);
+            intent.putExtra("id",poster.getId());
             intent.putExtra("url",poster.getTrailer().getUrl());
             intent.putExtra("type",poster.getTrailer().getType());
+            intent.putExtra("isLive",false); // Trailers are not live
+            intent.putExtra("kind","trailer");
             intent.putExtra("image",poster.getImage());
             intent.putExtra("title",poster.getTitle());
             intent.putExtra("subtitle",poster.getTitle() + " Trailer");

--- a/Movie/app/src/main/my/cinemax/app/free/ui/fragments/DownloadsFragment.java
+++ b/Movie/app/src/main/my/cinemax/app/free/ui/fragments/DownloadsFragment.java
@@ -194,6 +194,7 @@ public class DownloadsFragment extends Fragment  implements DownloadedAdapter.Do
                 intent1.putExtra("id",downloadItem.getElement());
                 intent1.putExtra("url",getIpAccess()+getPortFromEditText());
                 intent1.putExtra("type",type);
+                intent1.putExtra("isLive",false); // Downloaded content is never live
                 intent1.putExtra("kind",downloadItem.getType());
                 intent1.putExtra("image",downloadItem.getImage());
                 intent1.putExtra("title",downloadItem.getTitle());
@@ -211,6 +212,7 @@ public class DownloadsFragment extends Fragment  implements DownloadedAdapter.Do
             intent.putExtra("id",downloadItem.getElement());
             intent.putExtra("url",downloadItem.getPath());
             intent.putExtra("type",type);
+            intent.putExtra("isLive",false); // Downloaded content is never live
             intent.putExtra("kind",downloadItem.getType());
             intent.putExtra("image",downloadItem.getImage());
             intent.putExtra("title",downloadItem.getTitle());


### PR DESCRIPTION
Fix app crashes when playing content by adding null checks and ensuring all required intent extras are passed to PlayerActivity.

The app crashed due to `NullPointerException` in `PlayerActivity` when intent extras were missing or null, specifically for downloaded content and trailers which did not consistently provide all expected data like "isLive", "id", and "kind".

---

[Open in Web](https://cursor.com/agents?id=bc-42e41cda-096f-4d99-adff-37acf562ad3e) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-42e41cda-096f-4d99-adff-37acf562ad3e) • [Open Docs](https://docs.cursor.com/background-agent/web-and-mobile)